### PR TITLE
[#71] 주문 목록 및 주문 상세 내역 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/ordermanagement/application/domain/order/Order.java
+++ b/src/main/java/com/sparta/ordermanagement/application/domain/order/Order.java
@@ -6,10 +6,10 @@ import java.time.LocalDateTime;
 
 public class Order {
 
-    private Long id;
     private String orderUuid;
     private String userId;
     private String shopId;
+    private String shopName;
     private OrderState orderState;
     private OrderType orderType;
     private String deliveryAddress;
@@ -17,24 +17,20 @@ public class Order {
     private LocalDateTime createdAt;
     private boolean isDeleted;
 
-    public Order(Long id, String orderUuid, OrderState orderState,
+    public Order(String orderUuid, OrderState orderState,
                  OrderType orderType, String deliveryAddress, String requestOrder,
-                 String shopId, String userId, LocalDateTime createdAt, boolean isDeleted) {
+                 String shopId, String shopName, String userId, LocalDateTime createdAt, boolean isDeleted) {
 
-        this.id = id;
         this.orderUuid = orderUuid;
         this.orderState = orderState;
         this.orderType = orderType;
         this.deliveryAddress = deliveryAddress;
         this.requestOrder = requestOrder;
         this.shopId = shopId;
+        this.shopName = shopName;
         this.userId = userId;
         this.createdAt = createdAt;
         this.isDeleted = isDeleted;
-    }
-
-    public Long getId() {
-        return id;
     }
 
     public String getOrderUuid() {
@@ -58,6 +54,10 @@ public class Order {
     }
 
     public String getShopId() { return shopId; }
+
+    public String getShopName() {
+        return shopName;
+    }
 
     public String getUserId() {
         return userId;

--- a/src/main/java/com/sparta/ordermanagement/application/domain/order/TotalOrder.java
+++ b/src/main/java/com/sparta/ordermanagement/application/domain/order/TotalOrder.java
@@ -1,0 +1,102 @@
+package com.sparta.ordermanagement.application.domain.order;
+
+import com.sparta.ordermanagement.application.domain.orderproduct.OrderProduct;
+import com.sparta.ordermanagement.application.domain.payment.PaymentState;
+import com.sparta.ordermanagement.framework.persistence.entity.order.OrderType;
+
+import java.util.List;
+
+public class TotalOrder {
+
+    private String orderUuid;
+    private String userId;
+    private String shopId;
+    private String shopName;
+    private OrderState orderState;
+    private OrderType orderType;
+    private String deliveryAddress;
+    private String requestOrder;
+    private List<OrderProduct> orderProducts;
+    private String paymentUuid;
+    private PaymentState paymentState;
+    private Integer amount;
+    private String pgProvider;
+    private boolean isDeleted;
+
+    public TotalOrder(String orderUuid, String userId, String shopId, String shopName,
+                      OrderState orderState, OrderType orderType, String deliveryAddress,
+                      String requestOrder, List<OrderProduct> orderProducts, String paymentUuid,
+                      PaymentState paymentState, Integer amount, String pgProvider, boolean isDeleted) {
+
+        this.orderUuid = orderUuid;
+        this.userId = userId;
+        this.shopId = shopId;
+        this.shopName = shopName;
+        this.orderState = orderState;
+        this.orderType = orderType;
+        this.deliveryAddress = deliveryAddress;
+        this.requestOrder = requestOrder;
+        this.orderProducts = orderProducts;
+        this.paymentUuid = paymentUuid;
+        this.paymentState = paymentState;
+        this.amount = amount;
+        this.pgProvider = pgProvider;
+        this.isDeleted = isDeleted;
+    }
+
+    public String getOrderUuid() {
+        return orderUuid;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getShopId() {
+        return shopId;
+    }
+
+    public String getShopName() {
+        return shopName;
+    }
+
+    public OrderState getOrderState() {
+        return orderState;
+    }
+
+    public OrderType getOrderType() {
+        return orderType;
+    }
+
+    public String getDeliveryAddress() {
+        return deliveryAddress;
+    }
+
+    public String getRequestOrder() {
+        return requestOrder;
+    }
+
+    public List<OrderProduct> getOrderProducts() {
+        return orderProducts;
+    }
+
+    public String getPaymentUuid() {
+        return paymentUuid;
+    }
+
+    public PaymentState getPaymentState() {
+        return paymentState;
+    }
+
+    public Integer getAmount() {
+        return amount;
+    }
+
+    public String getPgProvider() {
+        return pgProvider;
+    }
+
+    public boolean getIsDeleted() {
+        return isDeleted;
+    }
+}

--- a/src/main/java/com/sparta/ordermanagement/application/domain/orderproduct/OrderProductForUpdate.java
+++ b/src/main/java/com/sparta/ordermanagement/application/domain/orderproduct/OrderProductForUpdate.java
@@ -1,4 +1,0 @@
-package com.sparta.ordermanagement.application.domain.orderproduct;
-
-public record OrderProductForUpdate() {
-}

--- a/src/main/java/com/sparta/ordermanagement/application/output/OrderOutputPort.java
+++ b/src/main/java/com/sparta/ordermanagement/application/output/OrderOutputPort.java
@@ -3,17 +3,23 @@ package com.sparta.ordermanagement.application.output;
 import com.sparta.ordermanagement.application.domain.order.Order;
 import com.sparta.ordermanagement.application.domain.order.OrderForCreate;
 import com.sparta.ordermanagement.application.domain.order.OrderForUpdate;
+import com.sparta.ordermanagement.application.domain.order.TotalOrder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.Optional;
 
 public interface OrderOutputPort {
 
     String saveOrder(OrderForCreate orderForCreate);
 
-    Optional<Order> findByOrderId(String orderId);
+    Optional<TotalOrder> findByOrderIdAndUserId(String orderId, String userId);
 
     String updateOrderState(OrderForUpdate orderForUpdate);
 
     String cancelOrder(Order order, String orderId);
 
     Optional<Order> findByOrderUuid(String orderUuid);
+
+    Page<TotalOrder> findByUserId(Pageable pageable, String userId);
 }

--- a/src/main/java/com/sparta/ordermanagement/application/output/OrderProductOutputPort.java
+++ b/src/main/java/com/sparta/ordermanagement/application/output/OrderProductOutputPort.java
@@ -1,9 +1,12 @@
 package com.sparta.ordermanagement.application.output;
 
 import com.sparta.ordermanagement.application.domain.orderproduct.OrderProduct;
+import com.sparta.ordermanagement.framework.persistence.entity.orderproduct.OrderProductEntity;
 
 import java.util.List;
 
 public interface OrderProductOutputPort {
     List<OrderProduct> findOrderProductsByOrderId(String orderId);
+
+    List<OrderProduct> findByOrder_OrderUuidIn(List<String> orderIds);
 }

--- a/src/main/java/com/sparta/ordermanagement/application/output/PaymentOutputPort.java
+++ b/src/main/java/com/sparta/ordermanagement/application/output/PaymentOutputPort.java
@@ -4,6 +4,7 @@ import com.sparta.ordermanagement.application.domain.payment.Payment;
 import com.sparta.ordermanagement.application.domain.payment.PaymentForUpdate;
 
 public interface PaymentOutputPort {
+
     String savePayment(String orderId);
 
     Payment processPayment(PaymentForUpdate paymentForUpdate, int amount);

--- a/src/main/java/com/sparta/ordermanagement/application/service/OrderService.java
+++ b/src/main/java/com/sparta/ordermanagement/application/service/OrderService.java
@@ -76,12 +76,12 @@ public class OrderService {
     }
 
     private Order validateOrderIdAndGetOrder(String orderId) {
-        return orderOutPutPort.findByOrderId(orderId)
+        return orderOutPutPort.findByOrderUuid(orderId)
                 .orElseThrow(() -> new InvalidOrderException(orderId));
     }
 
     public Order validateOrderUuidAndGetOrder(String orderId) {
-        return orderOutPutPort.findByOrderId(orderId)
+        return orderOutPutPort.findByOrderUuid(orderId)
                 .orElseThrow(() -> new OrderUuidInvalidException(orderId));
     }
 

--- a/src/main/java/com/sparta/ordermanagement/application/service/PaymentService.java
+++ b/src/main/java/com/sparta/ordermanagement/application/service/PaymentService.java
@@ -48,7 +48,7 @@ public class PaymentService {
         userOutputPort.findByUserStringId(userId)
                 .orElseThrow(() -> new UserIdInvalidException(userId));
 
-        Order order = orderOutputPort.findByOrderId(orderId)
+        Order order = orderOutputPort.findByOrderUuid(orderId)
                 .orElseThrow(() -> new InvalidOrderException(orderId));
 
         if (order.getUserId().equals(userId)) {
@@ -59,9 +59,10 @@ public class PaymentService {
     }
 
     private int calculateTotalOrderPrice(List<OrderProduct> orderProducts) {
-        return orderProducts.stream()
+        return orderProducts.stream().mapToInt(OrderProduct::getOrderPrice).sum();
+                /* count 랑 OrderPrice 합쳐서 계산 할 경우
                 .mapToInt(orderProduct -> orderProduct.getCount() * orderProduct.getOrderPrice())
-                .sum();
+                .sum(); */
     }
 
     public void validateOrderCheckCanceled(Order order) {

--- a/src/main/java/com/sparta/ordermanagement/bootstrap/admin/controller/adminOrderController.java
+++ b/src/main/java/com/sparta/ordermanagement/bootstrap/admin/controller/adminOrderController.java
@@ -52,6 +52,8 @@ public class adminOrderController {
                 .map(OrderResponse::from);
     }
 
+    @PaginationConstraint
+
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{orderId}")
     @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")

--- a/src/main/java/com/sparta/ordermanagement/bootstrap/admin/dto/OrderProductResponse.java
+++ b/src/main/java/com/sparta/ordermanagement/bootstrap/admin/dto/OrderProductResponse.java
@@ -12,6 +12,7 @@ public class OrderProductResponse {
 
     private Long orderProductId;
     private String productUuid;
+    private String productName;
     private Integer count;
     private Integer orderPrice;
 
@@ -19,6 +20,7 @@ public class OrderProductResponse {
         return new OrderProductResponse(
                 orderProductEntity.getId(),
                 orderProductEntity.getProductEntity().getProductUuid(),
+                orderProductEntity.getProductEntity().getProductName(),
                 orderProductEntity.getCount(),
                 orderProductEntity.getOrderPrice()
         );

--- a/src/main/java/com/sparta/ordermanagement/bootstrap/admin/dto/OrderResponse.java
+++ b/src/main/java/com/sparta/ordermanagement/bootstrap/admin/dto/OrderResponse.java
@@ -3,6 +3,7 @@ package com.sparta.ordermanagement.bootstrap.admin.dto;
 import com.sparta.ordermanagement.application.domain.order.OrderState;
 import com.sparta.ordermanagement.framework.persistence.entity.order.OrderEntity;
 import com.sparta.ordermanagement.framework.persistence.entity.order.OrderType;
+import com.sparta.ordermanagement.framework.persistence.entity.payment.PaymentEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -20,6 +21,9 @@ public class OrderResponse {
     private String requestOrder;
     private String userId;
     private String shopId;
+    private String shopName;
+    private String paymentUuid;
+    private Integer amount;
     private List<OrderProductResponse> orderProducts;
 
     private History history;
@@ -29,6 +33,11 @@ public class OrderResponse {
                 .map(OrderProductResponse::from)
                 .toList();
 
+        PaymentEntity paymentEntity = orderEntity.getPaymentEntity();
+
+        String paymentUuid = (paymentEntity != null) ? paymentEntity.getPaymentUuid() : null;
+        Integer paymentAmount = (paymentEntity != null) ? paymentEntity.getAmount() : null;
+
         return new OrderResponse(
                 orderEntity.getId(),
                 orderEntity.getOrderUuid(),
@@ -37,7 +46,10 @@ public class OrderResponse {
                 orderEntity.getDeliveryAddress(),
                 orderEntity.getRequestOrder(),
                 orderEntity.getUserEntity().getUserStringId(),
-                orderEntity.getShopId(),
+                orderEntity.getShopEntity().getShopUuid(),
+                orderEntity.getShopEntity().getShopName(),
+                paymentUuid,
+                paymentAmount,
                 orderProductResponses,
                 History.from(orderEntity)
         );

--- a/src/main/java/com/sparta/ordermanagement/bootstrap/admin/dto/OrderUpdateResponse.java
+++ b/src/main/java/com/sparta/ordermanagement/bootstrap/admin/dto/OrderUpdateResponse.java
@@ -40,7 +40,7 @@ public class OrderUpdateResponse {
                 orderEntity.getDeliveryAddress(),
                 orderEntity.getRequestOrder(),
                 orderEntity.getUserEntity().getUserStringId(),
-                orderEntity.getShopId(),
+                orderEntity.getShopEntity().getShopUuid(),
                 orderProductResponses,  // 변환된 orderProduct 목록
                 paymentUuid,
                 History.from(orderEntity)

--- a/src/main/java/com/sparta/ordermanagement/bootstrap/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/ordermanagement/bootstrap/filter/JwtAuthorizationFilter.java
@@ -17,6 +17,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.parameters.P;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -45,6 +46,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             Pattern.compile(String.format("^/api/v1/shops/%s/products/%s$", UUID_PATTERN, UUID_PATTERN)),
             Pattern.compile("^/api/v1/orders$"),
             Pattern.compile("^/api/v1/orders/payments$"),
+            Pattern.compile("^/api/v1/orders/owner$"),
             Pattern.compile(String.format("^/api/v1/orders/%s$", UUID_PATTERN)),
             Pattern.compile(String.format("^/api/v1/orders/%s/cancel$", UUID_PATTERN)),
             Pattern.compile(String.format("^/api/v1/orders/%s/reviews$", UUID_PATTERN)),

--- a/src/main/java/com/sparta/ordermanagement/bootstrap/rest/controller/OrderProductQueryController.java
+++ b/src/main/java/com/sparta/ordermanagement/bootstrap/rest/controller/OrderProductQueryController.java
@@ -1,4 +1,0 @@
-package com.sparta.ordermanagement.bootstrap.rest.controller;
-
-public class OrderProductQueryController {
-}

--- a/src/main/java/com/sparta/ordermanagement/bootstrap/rest/controller/OrderQueryController.java
+++ b/src/main/java/com/sparta/ordermanagement/bootstrap/rest/controller/OrderQueryController.java
@@ -1,4 +1,59 @@
 package com.sparta.ordermanagement.bootstrap.rest.controller;
 
+import com.sparta.ordermanagement.application.domain.order.TotalOrder;
+import com.sparta.ordermanagement.bootstrap.auth.UserDetailsImpl;
+import com.sparta.ordermanagement.bootstrap.rest.dto.order.OrderResponse;
+import com.sparta.ordermanagement.bootstrap.rest.exception.exceptions.OrderNotFoundException;
+import com.sparta.ordermanagement.bootstrap.rest.pagination.offset.PaginationConstraint;
+import com.sparta.ordermanagement.framework.persistence.adapter.OrderPersistenceAdapter;
+import com.sparta.ordermanagement.framework.persistence.adapter.ShopPersistenceAdapter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/orders")
 public class OrderQueryController {
+
+    private final OrderPersistenceAdapter orderPersistenceAdapter;
+    private final ShopPersistenceAdapter shopPersistenceAdapter;
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/{orderId}")
+    public OrderResponse findOrder(@PathVariable(value = "orderId") String orderId,
+                                   @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        TotalOrder totalOrder = orderPersistenceAdapter.findByOrderIdAndUserId(orderId, userDetails.getUserStringId())
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
+
+        return OrderResponse.from(totalOrder);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PaginationConstraint
+    @GetMapping
+    public Page<OrderResponse> findAll(Pageable pageable, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        return orderPersistenceAdapter
+                .findByUserId(pageable, userDetails.getUserStringId()).map(OrderResponse::from);
+
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('OWNER')")
+    @PaginationConstraint
+    @GetMapping("/owner")
+    public Page<OrderResponse> findAllByShop(Pageable pageable, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        String shopId = shopPersistenceAdapter.findByUserId(userDetails.getUserStringId());
+
+        return orderPersistenceAdapter.findByShopId(shopId, pageable).map(OrderResponse::from);
+    }
 }

--- a/src/main/java/com/sparta/ordermanagement/bootstrap/rest/dto/order/OrderListResponse.java
+++ b/src/main/java/com/sparta/ordermanagement/bootstrap/rest/dto/order/OrderListResponse.java
@@ -1,4 +1,0 @@
-package com.sparta.ordermanagement.bootstrap.rest.dto.order;
-
-public class OrderListResponse {
-}

--- a/src/main/java/com/sparta/ordermanagement/bootstrap/rest/dto/order/OrderProductResponse.java
+++ b/src/main/java/com/sparta/ordermanagement/bootstrap/rest/dto/order/OrderProductResponse.java
@@ -1,0 +1,27 @@
+package com.sparta.ordermanagement.bootstrap.rest.dto.order;
+
+import com.sparta.ordermanagement.application.domain.orderproduct.OrderProduct;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderProductResponse {
+
+    private String productUuid;
+    private String productName;
+    private Integer count;
+    private Integer orderPrice;
+
+    public static OrderProductResponse from(OrderProduct orderProduct) {
+
+        return new OrderProductResponse(
+                orderProduct.getProduct().getProductUuid(),
+                orderProduct.getProduct().getProductName(),
+                orderProduct.getCount(),
+                orderProduct.getOrderPrice()
+        );
+    }
+}

--- a/src/main/java/com/sparta/ordermanagement/bootstrap/rest/dto/order/OrderResponse.java
+++ b/src/main/java/com/sparta/ordermanagement/bootstrap/rest/dto/order/OrderResponse.java
@@ -1,0 +1,54 @@
+package com.sparta.ordermanagement.bootstrap.rest.dto.order;
+
+import com.sparta.ordermanagement.application.domain.order.OrderState;
+import com.sparta.ordermanagement.application.domain.order.TotalOrder;
+import com.sparta.ordermanagement.application.domain.payment.PaymentState;
+import com.sparta.ordermanagement.framework.persistence.entity.order.OrderType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class OrderResponse {
+
+    private String orderUuid;
+    private String userId;
+    private String shopId;
+    private String shopName;
+    private OrderState orderState;
+    private OrderType orderType;
+    private String deliveryAddress;
+    private String requestOrder;
+    private List<OrderProductResponse> orderProductList;
+    private String paymentUuid;
+    private PaymentState paymentState;
+    private Integer amount;
+    private String pgProvider;
+    private boolean isDeleted;
+
+    public static OrderResponse from(TotalOrder totalOrder) {
+
+        List<OrderProductResponse> orderProductResponseList =
+                totalOrder.getOrderProducts().stream()
+                        .map(OrderProductResponse::from).toList();
+
+        return new OrderResponse(
+                totalOrder.getOrderUuid(),
+                totalOrder.getUserId(),
+                totalOrder.getShopId(),
+                totalOrder.getShopName(),
+                totalOrder.getOrderState(),
+                totalOrder.getOrderType(),
+                totalOrder.getDeliveryAddress(),
+                totalOrder.getRequestOrder(),
+                orderProductResponseList,
+                totalOrder.getPaymentUuid(),
+                totalOrder.getPaymentState(),
+                totalOrder.getAmount(),
+                totalOrder.getPgProvider(),
+                totalOrder.getIsDeleted()
+        );
+    }
+}

--- a/src/main/java/com/sparta/ordermanagement/framework/admin/repository/AdminOrderRepository.java
+++ b/src/main/java/com/sparta/ordermanagement/framework/admin/repository/AdminOrderRepository.java
@@ -1,6 +1,5 @@
 package com.sparta.ordermanagement.framework.admin.repository;
 
-import com.sparta.ordermanagement.application.domain.order.Order;
 import com.sparta.ordermanagement.framework.persistence.entity.order.OrderEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/sparta/ordermanagement/framework/persistence/adapter/OrderProductPersistenceAdapter.java
+++ b/src/main/java/com/sparta/ordermanagement/framework/persistence/adapter/OrderProductPersistenceAdapter.java
@@ -25,4 +25,12 @@ public class OrderProductPersistenceAdapter implements OrderProductOutputPort {
                 .stream().map(OrderProductEntity::toDomain)
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    @Override
+    public List<OrderProduct> findByOrder_OrderUuidIn(List<String> orderIds) {
+        return orderProductRepository.findByOrderEntity_OrderUuidIn(orderIds)
+                .stream().map(OrderProductEntity::toDomain)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/sparta/ordermanagement/framework/persistence/adapter/PaymentPersistenceAdapter.java
+++ b/src/main/java/com/sparta/ordermanagement/framework/persistence/adapter/PaymentPersistenceAdapter.java
@@ -24,6 +24,7 @@ public class PaymentPersistenceAdapter implements PaymentOutputPort {
 
         OrderEntity orderEntity = orderRepository.findByOrderUuid(orderId).get();
         PaymentEntity paymentEntity = paymentRepository.save(PaymentEntity.from(orderEntity));
+        orderEntity.updatePayment(paymentEntity);
 
         return paymentEntity.getPaymentUuid();
     }

--- a/src/main/java/com/sparta/ordermanagement/framework/persistence/adapter/ShopPersistenceAdapter.java
+++ b/src/main/java/com/sparta/ordermanagement/framework/persistence/adapter/ShopPersistenceAdapter.java
@@ -2,18 +2,20 @@ package com.sparta.ordermanagement.framework.persistence.adapter;
 
 import com.sparta.ordermanagement.application.domain.shop.Shop;
 import com.sparta.ordermanagement.application.domain.shop.ShopForUpdate;
+import com.sparta.ordermanagement.application.exception.InvalidValueException;
 import com.sparta.ordermanagement.application.output.ShopOutputPort;
 import com.sparta.ordermanagement.framework.persistence.entity.shop.ShopEntity;
 import com.sparta.ordermanagement.framework.persistence.repository.ShopQueryRepository;
 import com.sparta.ordermanagement.framework.persistence.repository.ShopRepository;
 import com.sparta.ordermanagement.framework.persistence.vo.Cursor;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Component
@@ -62,5 +64,11 @@ public class ShopPersistenceAdapter implements ShopOutputPort {
     public List<Shop> findAllByKeyword(String keyword, Cursor cursor) {
         return shopQueryRepository.findAllByKeyword(keyword, cursor)
             .stream().map(ShopEntity::toDomain).toList();
+    }
+
+    public String findByUserId(String userStringId) {
+        return shopRepository.findByUserEntity_UserStringId(userStringId)
+                .map(ShopEntity::getShopUuid)
+                .orElseThrow(() -> new InvalidValueException("해당 유저의 가게 ID를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/sparta/ordermanagement/framework/persistence/entity/order/OrderEntity.java
+++ b/src/main/java/com/sparta/ordermanagement/framework/persistence/entity/order/OrderEntity.java
@@ -1,12 +1,12 @@
 package com.sparta.ordermanagement.framework.persistence.entity.order;
 
-import com.sparta.ordermanagement.application.domain.order.Order;
-import com.sparta.ordermanagement.application.domain.order.OrderForCreate;
-import com.sparta.ordermanagement.application.domain.order.OrderForUpdate;
-import com.sparta.ordermanagement.application.domain.order.OrderState;
+import com.sparta.ordermanagement.application.domain.order.*;
+import com.sparta.ordermanagement.application.domain.orderproduct.OrderProduct;
 import com.sparta.ordermanagement.bootstrap.admin.dto.OrderUpdateRequest;
 import com.sparta.ordermanagement.framework.persistence.entity.BaseEntity;
 import com.sparta.ordermanagement.framework.persistence.entity.orderproduct.OrderProductEntity;
+import com.sparta.ordermanagement.framework.persistence.entity.payment.PaymentEntity;
+import com.sparta.ordermanagement.framework.persistence.entity.shop.ShopEntity;
 import com.sparta.ordermanagement.framework.persistence.entity.user.UserEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -45,26 +45,31 @@ public class OrderEntity extends BaseEntity {
     @Column(columnDefinition = "varchar(255)")
     private String requestOrder;
 
-    @Column(columnDefinition = "varchar(255)")
-    private String shopId;
+    @JoinColumn(nullable = false)
+    @ManyToOne
+    private ShopEntity shopEntity;
 
     @JoinColumn(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private UserEntity userEntity;
+
+    @JoinColumn
+    @OneToOne(mappedBy = "orderEntity", fetch = FetchType.LAZY)
+    private PaymentEntity paymentEntity;
 
     @OneToMany(mappedBy = "orderEntity", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderProductEntity> orderProducts = new ArrayList<>();
 
     private OrderEntity(OrderState orderState,
                         OrderType orderType, String deliveryAddress,
-                        String requestOrder, String shopId, UserEntity userEntity) {
+                        String requestOrder, ShopEntity shopEntity, UserEntity userEntity) {
 
         id = null;
         this.orderState = orderState;
         this.orderType = orderType;
         this.deliveryAddress = deliveryAddress;
         this.requestOrder = requestOrder;
-        this.shopId = shopId;
+        this.shopEntity = shopEntity;
         this.userEntity = userEntity;
     }
 
@@ -75,18 +80,20 @@ public class OrderEntity extends BaseEntity {
 
     public Order toDomain() {
 
-        return new Order(id, orderUuid, orderState, orderType,
-                deliveryAddress, requestOrder, shopId, userEntity.getUserStringId(), super.getCreatedAt(), super.isDeleted());
+        return new Order(orderUuid, orderState, orderType,
+                deliveryAddress, requestOrder, shopEntity.getShopUuid(),
+                shopEntity.getShopName(), userEntity.getUserStringId(),
+                super.getCreatedAt(), super.isDeleted());
     }
 
-    public static OrderEntity from(OrderForCreate orderForCreate, UserEntity userEntity) {
+    public static OrderEntity from(OrderForCreate orderForCreate, ShopEntity shopEntity, UserEntity userEntity) {
 
         return new OrderEntity(
                 orderForCreate.orderState(),
                 orderForCreate.orderType(),
                 orderForCreate.deliveryAddress(),
                 orderForCreate.requestOrder(),
-                orderForCreate.shopId(),
+                shopEntity,
                 userEntity);
     }
 
@@ -110,5 +117,19 @@ public class OrderEntity extends BaseEntity {
 
     public void deleteFrom(String deletedUserId) {
         super.deleteFrom(deletedUserId);
+    }
+
+    public void updatePayment(PaymentEntity paymentEntity) {
+        this.paymentEntity = paymentEntity;
+    }
+
+    public TotalOrder totalOrder() {
+        List<OrderProduct> orderProductList = orderProducts.stream().map(OrderProductEntity::toDomain)
+                .toList();
+
+        return new TotalOrder(orderUuid, userEntity.getUserStringId(), shopEntity.getShopUuid(),
+                shopEntity.getShopName(), orderState, orderType, deliveryAddress, requestOrder,
+                orderProductList, paymentEntity.getPaymentUuid(), paymentEntity.getPaymentState(),
+                paymentEntity.getAmount(), paymentEntity.getPgProvider(), super.isDeleted());
     }
 }

--- a/src/main/java/com/sparta/ordermanagement/framework/persistence/repository/OrderProductRepository.java
+++ b/src/main/java/com/sparta/ordermanagement/framework/persistence/repository/OrderProductRepository.java
@@ -1,12 +1,17 @@
 package com.sparta.ordermanagement.framework.persistence.repository;
 
-import com.sparta.ordermanagement.application.domain.orderproduct.OrderProduct;
 import com.sparta.ordermanagement.framework.persistence.entity.orderproduct.OrderProductEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface OrderProductRepository extends JpaRepository<OrderProductEntity, String> {
 
-    List<OrderProductEntity> findByOrderEntity_OrderUuid(String orderId);
+    @Query("SELECT op FROM p_order_product op WHERE op.orderEntity.orderUuid = :orderUuid")
+    List<OrderProductEntity> findByOrderEntity_OrderUuid(@Param("orderUuid")String orderId);
+
+    @Query("SELECT op FROM p_order_product op WHERE op.orderEntity.orderUuid IN :orderUuids")
+    List<OrderProductEntity> findByOrderEntity_OrderUuidIn(@Param("orderUuids")List<String> orderIds);
 }

--- a/src/main/java/com/sparta/ordermanagement/framework/persistence/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/ordermanagement/framework/persistence/repository/OrderRepository.java
@@ -1,9 +1,13 @@
 package com.sparta.ordermanagement.framework.persistence.repository;
 
 import com.sparta.ordermanagement.framework.persistence.entity.order.OrderEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Range;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<OrderEntity, String> {
@@ -13,4 +17,13 @@ public interface OrderRepository extends JpaRepository<OrderEntity, String> {
 
     @Query("SELECT o FROM p_order o WHERE o.orderUuid = :orderUuid AND o.isDeleted = false")
     Optional<OrderEntity> findByOrderUuidAndIsDeletedFalse(String orderUuid);
+
+    @Query("SELECT o FROM p_order o WHERE o.orderUuid =:orderUuid AND o.userEntity.userStringId = :userStringId")
+    Optional<OrderEntity> findByOrderUuidAndUserEntity_UserStringId(@Param("orderUuid") String orderUuid, @Param("userStringId") String userStringId);
+
+    @Query("SELECT o FROM p_order o WHERE o.userEntity.userStringId = :userStringId")
+    Page<OrderEntity> findByUserEntity_UserStringId(@Param("userStringId") String userStringId, Pageable pageable);
+
+    @Query("SELECT o FROM p_order o WHERE o.shopEntity.shopUuid = :shopUuid")
+    Page<OrderEntity> findByShopEntity_ShopUuid(@Param("shopUuid") String shopUuid, Pageable pageable);
 }

--- a/src/main/java/com/sparta/ordermanagement/framework/persistence/repository/ShopRepository.java
+++ b/src/main/java/com/sparta/ordermanagement/framework/persistence/repository/ShopRepository.java
@@ -32,4 +32,7 @@ public interface ShopRepository extends JpaRepository<ShopEntity, String> {
     Page<ShopEntity> findAllByDeletedIsFalse(Pageable pageable);
 
     Optional<ShopEntity> findByShopUuid(String uuid);
+
+    @Query("SELECT s FROM p_shop s WHERE s.userEntity.userStringId =:userStringId")
+    Optional<ShopEntity> findByUserEntity_UserStringId(@Param("userStringId") String userStringId);
 }


### PR DESCRIPTION
## 📝 작업 내용

> 고객의 본인 전체 주문, 개별 주문 조회 기능 구현, 점주의 가게 전체 주문 조회 기능 구현
 - 해당 조회의 경우 본인에 해당하는 부분만 조회가 필요하므로 cusor 기반 조회는 구현하지 않았습니다.
 - shopId를 반정규화 했으나 조회 시 shopId를 가지고 다시 조회해야 하는 문제가 있어 연관관계 매핑으로 변경했습니다.
 - 결제 정보 역시 주문 조회 시 같이 조회될 수 있도록 주문 테이블과 양방향 연관관계를 맺었습니다.

## #️⃣ 연관 이슈
- #71

resolved: #71
