### PR TITLE
[#76] 결제 실패 시 결제 상태 변경 및 예외 처리

### DIFF
--- a/src/main/java/com/sparta/ordermanagement/application/exception/message/PaymentErrorMessage.java
+++ b/src/main/java/com/sparta/ordermanagement/application/exception/message/PaymentErrorMessage.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum PaymentErrorMessage {
 
-    USER_ORDER_ID_INVALID("주문에 대해 유효하지 않은 유저 아이디 입니다. : %s");
+    USER_ORDER_ID_INVALID("주문에 대해 유효하지 않은 유저 아이디 입니다. : %s"),
+    PAYMENT_PROCESS_FAILED("결제가 실패했습니다. 다시 시도해 주세요."),
+    PAYMENT_PROCESS_ERROR("결제 진행 중 문제가 발생했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/sparta/ordermanagement/application/exception/payment/PaymentFailedException.java
+++ b/src/main/java/com/sparta/ordermanagement/application/exception/payment/PaymentFailedException.java
@@ -1,0 +1,10 @@
+package com.sparta.ordermanagement.application.exception.payment;
+
+import static com.sparta.ordermanagement.application.exception.message.PaymentErrorMessage.PAYMENT_PROCESS_FAILED;
+
+public class PaymentFailedException extends RuntimeException {
+
+    public PaymentFailedException(Throwable cause) {
+        super(String.format(PAYMENT_PROCESS_FAILED.getMessage()), cause);
+    }
+}

--- a/src/main/java/com/sparta/ordermanagement/application/exception/payment/PaymentProcessingException.java
+++ b/src/main/java/com/sparta/ordermanagement/application/exception/payment/PaymentProcessingException.java
@@ -1,0 +1,10 @@
+package com.sparta.ordermanagement.application.exception.payment;
+
+import static com.sparta.ordermanagement.application.exception.message.PaymentErrorMessage.PAYMENT_PROCESS_ERROR;
+
+public class PaymentProcessingException extends RuntimeException {
+
+    public PaymentProcessingException() {
+        super(String.format(PAYMENT_PROCESS_ERROR.getMessage()));
+    }
+}

--- a/src/main/java/com/sparta/ordermanagement/framework/persistence/adapter/PaymentPersistenceAdapter.java
+++ b/src/main/java/com/sparta/ordermanagement/framework/persistence/adapter/PaymentPersistenceAdapter.java
@@ -2,6 +2,8 @@ package com.sparta.ordermanagement.framework.persistence.adapter;
 
 import com.sparta.ordermanagement.application.domain.payment.Payment;
 import com.sparta.ordermanagement.application.domain.payment.PaymentForUpdate;
+import com.sparta.ordermanagement.application.exception.payment.PaymentFailedException;
+import com.sparta.ordermanagement.application.exception.payment.PaymentProcessingException;
 import com.sparta.ordermanagement.application.output.PaymentOutputPort;
 import com.sparta.ordermanagement.framework.persistence.entity.order.OrderEntity;
 import com.sparta.ordermanagement.framework.persistence.entity.payment.PaymentEntity;
@@ -33,7 +35,14 @@ public class PaymentPersistenceAdapter implements PaymentOutputPort {
     @Override
     public Payment processPayment(PaymentForUpdate paymentForUpdate, int amount) {
         PaymentEntity paymentEntity = paymentRepository.findByPaymentUuid(paymentForUpdate.paymentUuid()).get();
-        paymentEntity.processPayment(paymentForUpdate, amount);
+
+        try {
+            paymentEntity.processPayment(paymentForUpdate, amount);
+        } catch (PaymentProcessingException e) {
+            paymentEntity.failedState();
+
+            throw new PaymentFailedException(e);
+        }
 
         return  paymentEntity.toDomain();
     }

--- a/src/main/java/com/sparta/ordermanagement/framework/persistence/entity/payment/PaymentEntity.java
+++ b/src/main/java/com/sparta/ordermanagement/framework/persistence/entity/payment/PaymentEntity.java
@@ -75,4 +75,8 @@ public class PaymentEntity extends BaseEntity {
 
         return new Payment(id, orderEntity.getOrderUuid(), paymentUuid, amount, paymentState, pgProvider);
     }
+
+    public void failedState() {
+        paymentState = PaymentState.FAILED;
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용

> 결제 실패 시 결제 상태 변경 및 예외 처리
 - 결제 진행 중 에러 발생 등으로 인한 문제 발생 시 결제 상태 취소로 변경 및 예외 메시지 반환

## #️⃣ 연관 이슈
- #76

resolved: #76